### PR TITLE
Add Bricks to brick break

### DIFF
--- a/02_breakout/app/Linear/GJK.hs
+++ b/02_breakout/app/Linear/GJK.hs
@@ -1,11 +1,8 @@
 module Linear.GJK (minkCircle, minkRectangle, minkPoly, minkSegment) where
 
-import GJK.Mink      (Mink(..))
+import GJK.Mink      (Mink)
 import GJK.Point     (Pt, dot)
 import GJK.Support   (polySupport)
-import GHC.Float (float2Double)
-import Debug.Trace (trace)
-import GJK.Collision
 
 import Linear.V2 ( V2 (V2) )
 
@@ -26,13 +23,10 @@ minkPoly :: [V2 Double] -> Mink [V2 Double]
 minkPoly points = (points, polySupport')
 
 minkRectangle :: V2 Double -> V2 Double -> Mink [V2 Double]
-minkRectangle c s = minkPoly $ points c s
-  where
-    points :: V2 Double -> V2 Double -> [V2 Double]
-    -- points c s | (trace (show c ++ " " ++ show s) False) = undefined
-    points c@(V2 x y) s@(V2 w h) = ((+) $ V2 (-w/2) (-h/2)) <$> [c, c + (V2 w 0), c + s, c + (V2 0 h)]
+minkRectangle c s@(V2 w h) = minkPoly points
+  where points = ((+) $ V2 (-w/2) (-h/2)) <$> [c, c + (V2 w 0), c + s, c + (V2 0 h)]
 
 minkSegment :: V2 Double -> V2 Double -> Mink (V2 Double, V2 Double)
 minkSegment a b = ((a, b), support)
   where
-    support (a, b) = polySupport' [a, b]
+    support (a', b') = polySupport' [a', b']

--- a/02_breakout/app/Linear/GJK.hs
+++ b/02_breakout/app/Linear/GJK.hs
@@ -1,10 +1,11 @@
-module Linear.GJK (minkCircle, minkRectangle, minkPoly) where
+module Linear.GJK (minkCircle, minkRectangle, minkPoly, minkSegment) where
 
 import GJK.Mink      (Mink(..))
 import GJK.Point     (Pt, dot)
 import GJK.Support   (polySupport)
 import GHC.Float (float2Double)
 import Debug.Trace (trace)
+import GJK.Collision
 
 import Linear.V2 ( V2 (V2) )
 
@@ -18,10 +19,11 @@ circleSupport (r, (V2 x y)) d@(a,b) =
 minkCircle :: Double -> V2 Double -> Mink (Double, V2 Double)
 minkCircle r p = ((r, p), circleSupport)
 
+polySupport' :: [V2 Double] -> Pt -> Maybe Pt
+polySupport' = polySupport . (fmap (\(V2 a b) -> (a, b)))
+
 minkPoly :: [V2 Double] -> Mink [V2 Double]
-minkPoly points = (points, support)
-  where
-    support = polySupport . (fmap (\(V2 a b) -> (a, b)))
+minkPoly points = (points, polySupport')
 
 minkRectangle :: V2 Double -> V2 Double -> Mink [V2 Double]
 minkRectangle c s = minkPoly $ points c s
@@ -29,3 +31,8 @@ minkRectangle c s = minkPoly $ points c s
     points :: V2 Double -> V2 Double -> [V2 Double]
     -- points c s | (trace (show c ++ " " ++ show s) False) = undefined
     points c@(V2 x y) s@(V2 w h) = ((+) $ V2 (-w/2) (-h/2)) <$> [c, c + (V2 w 0), c + s, c + (V2 0 h)]
+
+minkSegment :: V2 Double -> V2 Double -> Mink (V2 Double, V2 Double)
+minkSegment a b = ((a, b), support)
+  where
+    support (a, b) = polySupport' [a, b]

--- a/02_breakout/app/Main.hs
+++ b/02_breakout/app/Main.hs
@@ -152,8 +152,13 @@ brickBounces = proc (b, bs) -> do
 ballReset :: SF (BallMink, ScreenSize) (Event ())
 ballReset = proc (((r, (V2 x y)), _) , (V2 w h)) -> edge -< y < -(fromIntegral h)/2
 
+acc :: SF Vel Vel
+acc = proc v -> do
+  a <- integral -< 0.05
+  returnA -< (1 + a) * v
+
 ball :: SF BounceE BallMink
-ball = (bVelocity $ V2 50 (-100)) >>> (position $ V2 0 0) >>> (collisionCircle 8)
+ball = (bVelocity $ V2 50 (-100)) >>> acc >>> (position $ V2 0 (-50)) >>> (collisionCircle 8)
 
 paddle :: SF VelDirection PaddleMink
 paddle = lVelocity (V2 100 0) >>> (position $ V2 0 (-100)) >>> (collisionRectangle $ V2 50 5)

--- a/02_breakout/app/Main.hs
+++ b/02_breakout/app/Main.hs
@@ -234,7 +234,7 @@ game' = proc gi -> do
                         ] ++ (drawRectangle <$> fst <$> bs)
 
 defaultPlay :: SF (Event InputEvent) Picture -> IO ()
-defaultPlay = playYampa (InWindow "Pong" (300, 500) (200, 200)) white 60
+defaultPlay = playYampa (InWindow "Breakout" (300, 500) (200, 200)) white 60
 
 main :: IO ()
 main = defaultPlay $ input >>> game'

--- a/02_breakout/app/Main.hs
+++ b/02_breakout/app/Main.hs
@@ -5,7 +5,7 @@ import Control.Applicative                ( liftA2 )
 import FRP.Yampa                          ( SF, Event (Event, NoEvent), VectorSpace((*^))
                                           , tag, catEvents, accumHold, constant, isEvent
                                           , accumHoldBy, edgeTag, repeatedly, gate, tagWith
-                                          , edge, iPre, merge, integral, hold, dpSwitch, iPre
+                                          , edge, iPre, merge, integral, hold, pSwitch, iPre
                                           , drSwitch, edgeJust, parB, pSwitchB, event, delay, dropEvents )
 import Graphics.Gloss                     ( Display (InWindow)
                                           , Picture (Pictures, Translate, Color)
@@ -175,19 +175,10 @@ brick s p = proc e -> do
   c <- hold Just -< e `tag` (const Nothing)
   returnA -< c bm
 
--- arrList :: SF a b -> SF [a] [b]
--- arrList sf = 
-
--- cat' :: SF a b -> SF a b -> SF [a] [b]
--- cat' a b = 
-
--- flat' :: [SF a b] -> SF [a] [b]
--- flat' sfs = undefined
-
 bricks :: [SF (Event ()) (Maybe BrickMink)] -> SF [Event a] [BrickMink]
 bricks bs0 = bricks' bs0 >>^ catMaybes
   where
-    bricks' bs = dpSwitch route bs kill cont
+    bricks' bs = pSwitch route bs kill cont
     route es = zip $ (fmap (tagWith ()) es) ++ repeat NoEvent
     kill = (coll . (fmap (not . null)) . snd) ^>> dropEvents 1
     coll bs = bool (Event bs) NoEvent (and bs)

--- a/02_breakout/app/Main.hs
+++ b/02_breakout/app/Main.hs
@@ -215,15 +215,15 @@ paddleD _ _ = VelZero
 game' :: SF GameInput Picture
 game' = proc gi -> do
   rec
-    r               <- ballReset       -< (b, screenSize gi)
-    bcs             <- brickCollisions -< (b, bs)
-    dbcs            <- iPre []         -< bcs
-    wb              <- wallBounce      -< (b, screenSize gi)
-    pb              <- paddleBounce    -< (b, p)
-    bb              <- brickBounces    -< (b, bcs)
-    p@(ps, _)       <- paddle          -< paddleD (keyRight gi) (keyLeft gi)
-    b@((br, bp), _) <- drSwitch ball   -< (mergeC [wb, pb, bb], r `tag` ball)
-    bs              <- bricks1         -< dbcs
+    r               <- ballReset        -< (b, screenSize gi)
+    bcs             <- brickCollisions  -< (b, bs)
+    dbcs            <- iPre []          -< bcs
+    wb              <- wallBounce       -< (b, screenSize gi)
+    pb              <- paddleBounce     -< (b, p)
+    bb              <- brickBounces     -< (b, bcs)
+    p@(ps, _)       <- paddle           -< paddleD (keyRight gi) (keyLeft gi)
+    b@((br, bp), _) <- drSwitch ball    -< (mergeC [wb, pb, bb], r `tag` ball)
+    bs              <- drSwitch bricks1 -< (dbcs, r `tag` bricks1)
   returnA -< Pictures $ [ drawBall bp br
                         , drawRectangle ps
                         ] ++ (drawRectangle <$> fst <$> bs)

--- a/02_breakout/app/Main.hs
+++ b/02_breakout/app/Main.hs
@@ -137,8 +137,7 @@ brickCollisions = proc (b, bs) -> do
 
 brickBounces :: SF (BallMink, [Event BrickMink]) BounceE
 brickBounces = proc (b, bs) -> do
-  -- TODO: use catEvents
-  returnA -< mergeC $ Event <$> collision'' b <$> (catMaybes $ eventToMaybe <$> bs)
+  returnA -< mergeC $ (fmap $ collision'' b) <$> bs
   where
     -- TODO: break this out
     collision'' :: BallMink -> BrickMink -> BounceV

--- a/02_breakout/breakout.cabal
+++ b/02_breakout/breakout.cabal
@@ -63,16 +63,15 @@ executable breakout
 
     -- Modules included in this executable, other than Main.
     other-modules:
-        Ball,
-        Paddle,
         Linear.VectorSpace
+        Linear.GJK
 
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:
 
     -- Other library packages from which modules are imported.
     build-depends:
-        base ^>=4.17.2.1,
+        base ^>=4.18,
         yampa-gloss ^>=0.2,
         Yampa ^>=0.14,
         gloss ^>=1.13,


### PR DESCRIPTION
commit b8c424918f65af3e38c3785fb9e6a74dd5570f37 (HEAD -> bricks, origin/bricks)
Author: Brendan DeLeeuw <test>
Date:   Sun Jul 14 15:53:59 2024 -0600

    Cleanup
    
    unused imports, values without types, name shadowing, old comments, and cabal file

commit 25886fe12f0b4fd42f11d17259bc2551e8efc7a8
Author: Brendan DeLeeuw <test>
Date:   Sun Jul 14 15:10:17 2024 -0600

    Bricks reset on ball loss

commit d46a4adf6fdcedfa06bb32a8f7166f5d6c835d67
Author: Brendan DeLeeuw <test>
Date:   Sun Jul 14 15:08:47 2024 -0600

    Use regular switch for bricks instead of delayed
    
    There doesn't seem to be a reason to delay it and it works fine without it

commit 04405fff689dd9cafc69e60b88a2ce0b5244f6f8
Author: Brendan DeLeeuw <test>
Date:   Sun Jul 14 15:07:55 2024 -0600

    simpler brick bounce mapping

commit 134b7369113761ddb052901b1a65188ef757bc4f
Author: Brendan DeLeeuw <test>
Date:   Fri Jul 12 15:53:36 2024 -0600

    Ball accelerates over time

commit ce43c200ff5b1be41842f83b840b73440bbe3e38
Author: Brendan DeLeeuw <test>
Date:   Fri Jul 12 15:27:13 2024 -0600

    Window name show correct game name

commit 2ec37f4cd8f77a50f69f8f698e9c870acd37da18
Author: Brendan DeLeeuw <test>
Date:   Fri Jul 12 15:23:08 2024 -0600

    Example bricks that take 2 hits to destroy

commit 2e2c2bc209588f26e53968675add2f3f800d8170
Author: Brendan DeLeeuw <test>
Date:   Fri Jul 12 15:04:46 2024 -0600

    ball collision only removes one block

commit 54fa9cdb3834a736b33c405f1957b631efa1fb56
Author: Brendan DeLeeuw <test>
Date:   Fri Jul 12 13:53:50 2024 -0600

    Bricks bounce the ball and disappear afterwards

commit 5b070a202c57b6927705dd914159f6da73215c05
Author: Brendan DeLeeuw <test>
Date:   Thu Jul 11 21:14:03 2024 -0600

    Setting up signal functions to figure out when brick collisions happen and how the ball should bounce off those collisions
